### PR TITLE
Add missing margin type from ITextOpts

### DIFF
--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -354,6 +354,7 @@ export interface ITextOpts extends PositionOptions, OptsDataOrPath {
 	lineIdx?: number
 	lineSize?: number
 	lineSpacing?: number
+	margin?: number
 	outline?: { color: Color; size: number }
 	paraSpaceAfter?: number
 	paraSpaceBefore?: number

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -490,6 +490,7 @@ declare namespace PptxGenJS {
 		lineIdx?: number
 		lineSize?: number
 		lineSpacing?: number
+		margin?: number
 		outline?: { color: Color; size: number }
 		paraSpaceAfter?: number
 		paraSpaceBefore?: number


### PR DESCRIPTION
This type is listed in the documentation and does work, but was not in the types file. I think these are the only two places it's needed to be added?